### PR TITLE
Resuelta warning de JavaFX, tests funcionando en cualquier SO y hotfixes de marcado

### DIFF
--- a/simae/src/main/java/simae/SimaeLauncher.java
+++ b/simae/src/main/java/simae/SimaeLauncher.java
@@ -81,7 +81,7 @@ public class SimaeLauncher {
         return writeFile(outputFileName) ? 0 : 2;
     }
 
-    public static String launchTagging(String entrada, Lenguaje lenguaje) throws IOException {
+    public static String launchTagging(String entrada, Lenguaje lenguaje, String idioma) throws IOException {
 
         StringReader srEntrada = new StringReader(entrada);
         BufferedReader reader = new BufferedReader(srEntrada);
@@ -89,7 +89,7 @@ public class SimaeLauncher {
         StringWriter swSalida = new StringWriter();
         PrintWriter writer = new PrintWriter(swSalida);
 
-        Simae.fuenteMarcado(reader, writer, lenguaje, null);
+        Simae.fuenteMarcado(reader, writer, lenguaje, idioma);
 
         String salida = swSalida.toString();
 

--- a/simae/src/main/java/simae/lib/listener/JavaListener.java
+++ b/simae/src/main/java/simae/lib/listener/JavaListener.java
@@ -139,10 +139,19 @@ public class JavaListener extends JavaParserBaseListener {
 				texto));
 	}
 
+	public void enterIfElseStatement(JavaParser.IfElseStatementContext ctx) {
+		//IF parExpression statement elseStatement
+		String texto = strings.get("endsOn") + ctx.statement().getStop().getLine();
+		Token parentesis = ctx.parExpression().getStop();
+		marcas.add(new AnotacionMarca(parentesis.getLine(),
+				parentesis.getCharPositionInLine(),
+				texto));
+	}
+
 	@Override
 	public void enterElseStatement(JavaParser.ElseStatementContext ctx) {
 		//ELSE statement;
-		String texto = strings.get("closes") + strings.get("ofLine") + ctx.statement().getStop().getLine();
+		String texto = strings.get("endsOn") + ctx.statement().getStop().getLine();
 		Token elseT = (Token)ctx.getChild(ctx.getChildCount() - 2).getPayload();
 		marcas.add(new AnotacionMarca(elseT.getLine(),
 				elseT.getCharPositionInLine() + 3,
@@ -182,7 +191,7 @@ public class JavaListener extends JavaParserBaseListener {
 	public void exitWhileStatement(JavaParser.WhileStatementContext ctx) {
 		//WHILE parExpression statement
 		String whileCompleto = getOriginalCode(ctx.getStart(), ctx.parExpression().getStop());
-		String texto = strings.get("closes") + whileCompleto + strings.get("onLine") + ctx.getStart().getLine();
+		String texto = strings.get("closes") + whileCompleto + strings.get("ofLine") + ctx.getStart().getLine();
 
 		marcas.add(new AnotacionMarca(ctx.getStop().getLine(),
 				ctx.getStop().getCharPositionInLine(),

--- a/simae/src/main/java/simae/lib/listener/PythonListener.java
+++ b/simae/src/main/java/simae/lib/listener/PythonListener.java
@@ -187,11 +187,8 @@ public class PythonListener extends Python3ParserBaseListener {
 	@Override
 	public void exitIf_stmt_else(Python3Parser.If_stmt_elseContext ctx) {
 		//'else' ':' suite; //agregado para implementacion simae
-		int linea = ctx.getStop().getLine();
-		int posicionEnCaracter = ctx.getStop().getCharPositionInLine();
-		String lineaCompleta = ctx.getStop().getText();
 
-		String texto = "CIERRA else DE LÍNEA " + ctx.getStart().getLine();
+		String texto = strings.get("closes") + "else" + strings.get("ofLine") + ctx.getStart().getLine();
 
 		if(ctx.suite().DEDENT() != null) {
 			marcas.add(new AnotacionMarca(ultimoSuiteLine,
@@ -215,7 +212,7 @@ public class PythonListener extends Python3ParserBaseListener {
 	public void exitWhile_stmt_while(Python3Parser.While_stmt_whileContext ctx) {
 		//while' test ':' suite (if_stmt_else)?;
 		String whileCompleto = getOriginalCode(ctx.getStart(), ctx.test().getStop());
-		String texto = strings.get("closes") + whileCompleto + " DE LINEA " + ctx.getStart().getLine();
+		String texto = strings.get("closes") + whileCompleto + strings.get("ofLine") + ctx.getStart().getLine();
 
 		marcas.add(new AnotacionMarca(ultimoSuiteLine,
 				ultimoSuiteCharPosLine,

--- a/simae/src/main/resources/simae/gui/selector.fxml
+++ b/simae/src/main/resources/simae/gui/selector.fxml
@@ -41,7 +41,7 @@
 <?import javafx.scene.text.Font?>
 <?import javafx.scene.text.Text?>
 
-<VBox prefHeight="400.0" prefWidth="640.0" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="simae.gui.SelectorApplicationController">
+<VBox prefHeight="400.0" prefWidth="640.0" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1" fx:controller="simae.gui.SelectorApplicationController">
   <children>
     <AnchorPane maxHeight="-1.0" maxWidth="-1.0" prefHeight="531.0" prefWidth="968.0" VBox.vgrow="ALWAYS">
       <children>

--- a/simae/src/test/java/simae/lib/cPlusPlus/ArchivoConDeclaracionDeDosVariablesTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/ArchivoConDeclaracionDeDosVariablesTest.java
@@ -15,7 +15,7 @@ class ArchivoConDeclaracionDeDosVariablesTest extends Tests{
 				 "int b = 4;";
 		 esperado = "int a = 4;" + nl +
 				 	"int b = 4;" + nl; 
-		 marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS);
+		 marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "es");
 		 assertEquals(esperado,marcado, "No son iguales.");
 	}
 

--- a/simae/src/test/java/simae/lib/cPlusPlus/ArchivoConDeclaracionDeVariableTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/ArchivoConDeclaracionDeVariableTest.java
@@ -14,7 +14,7 @@ class ArchivoConDeclaracionDeVariableTest extends Tests{
 		 
 		 prog = "int a = 4;" + nl;
 		 esperado = "int a = 4;" + nl;
-		 marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS);
+		 marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "es");
 		 assertEquals(esperado,marcado, "No son iguales.");
 	}
 

--- a/simae/src/test/java/simae/lib/cPlusPlus/ArchivoConIncludeTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/ArchivoConIncludeTest.java
@@ -15,7 +15,7 @@ class ArchivoConIncludeTest extends Tests{
 				 "int a = 4;" + nl;
 		 esperado = "#include <iostream>" + nl +
 				 	"int a = 4;" + nl;
-		 marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS);
+		 marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "es");
 		 assertEquals(esperado,marcado, "No son iguales.");
 	}
 

--- a/simae/src/test/java/simae/lib/cPlusPlus/ClassTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/ClassTest.java
@@ -23,7 +23,7 @@ class ClassTest extends Tests {
  				  "    char buffer[255];" + nl +
 				  "    void llamadoFuncion(const char *argumento);" + nl +
 				  "}/*/CIERRA class CRender  DE LINEA 1/*/;" + nl;
-		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS);
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");
 	}
 }

--- a/simae/src/test/java/simae/lib/cPlusPlus/DoWhileTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/DoWhileTest.java
@@ -20,7 +20,7 @@ class DoWhileTest extends Tests {
 		  		"	do/*/CIERRA EN LINEA 3/*/ {" + nl + 
 		  		"	} while(c<0);/*/CIERRA do while DE LINEA 2/*/" + nl +
 		  		"}/*/CIERRA main() DE LINEA 1/*/" + nl;
-		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS);
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "es");
 
 		  assertEquals(esperado,marcado, "No son iguales.");
 	}

--- a/simae/src/test/java/simae/lib/cPlusPlus/DosMarcasJuntasTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/DosMarcasJuntasTest.java
@@ -25,7 +25,7 @@ class DosMarcasJuntasTest extends Tests{
 		 		"	}/*/CIERRA if(c) DE LINEA 4 y CIERRA while(c) DE LINEA 3/*/" + nl + 
 		 		"" + nl +
 		 		"}/*/CIERRA main() DE LINEA 1/*/" + nl;
-		 marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS);
+		 marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "es");
 		 assertEquals(esperado,marcado, "No son iguales.");
 	}
 

--- a/simae/src/test/java/simae/lib/cPlusPlus/ForConComentarioTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/ForConComentarioTest.java
@@ -23,7 +23,7 @@ class ForConComentarioTest extends Tests {
 			  		"		c++;" + nl +
 			  		"	}/*/CIERRA for(int i = 0; i< 10; i++) DE LINEA 2/*/" + nl +
 			  		"}/*/CIERRA main() DE LINEA 1/*/" + nl;
-		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS);
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");
 	}
 }

--- a/simae/src/test/java/simae/lib/cPlusPlus/ForDosLineasConComentarioTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/ForDosLineasConComentarioTest.java
@@ -24,7 +24,7 @@ class ForDosLineasConComentarioTest extends Tests {
 		  		"		c++;" + nl +
 		  		"	}/*/CIERRA for(int i = 0; i<10; i++) DE LINEA 2/*/" + nl +
 		  		"}/*/CIERRA main() DE LINEA 1/*/" + nl;
-		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS);
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");
 	}
 }

--- a/simae/src/test/java/simae/lib/cPlusPlus/ForDosLineasTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/ForDosLineasTest.java
@@ -24,7 +24,7 @@ class ForDosLineasTest extends Tests {
 		  		"		c++;" + nl +
 		  		"	}/*/CIERRA for(int i = 0; i<10; i++) DE LINEA 2/*/" + nl +
 		  		"}/*/CIERRA main() DE LINEA 1/*/" + nl;
-		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS);
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");
 	}
 }

--- a/simae/src/test/java/simae/lib/cPlusPlus/ForEachTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/ForEachTest.java
@@ -22,7 +22,7 @@ class ForEachTest extends Tests {
 		  		"		c++;" + nl +
 		  		"	}/*/CIERRA for(int it : vector) DE LINEA 2/*/" + nl + 
 		  		"}/*/CIERRA main() DE LINEA 1/*/" + nl;
-		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS);
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");
 	}
 }

--- a/simae/src/test/java/simae/lib/cPlusPlus/ForTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/ForTest.java
@@ -23,7 +23,7 @@ class ForTest extends Tests {
 			  		"		c++;" + nl +
 			  		"	}/*/CIERRA for(int i = 0; i<10; i++) DE LINEA 2/*/" + nl +
 			  		"}/*/CIERRA main() DE LINEA 1/*/" + nl;
-		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS);
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");
 	}
 }

--- a/simae/src/test/java/simae/lib/cPlusPlus/IfElseIfTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/IfElseIfTest.java
@@ -27,7 +27,7 @@ class IfElseIfTest extends Tests {
 		  		"		c--;" + nl +
 		  		"	}/*/CIERRA if(c) DE LINEA 5 y CIERRA else DE LINEA 5/*/" + nl +
 		  		"}/*/CIERRA main() DE LINEA 1/*/" + nl;
-		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS);
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");
 	}
 }

--- a/simae/src/test/java/simae/lib/cPlusPlus/IfElseTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/IfElseTest.java
@@ -27,7 +27,7 @@ class IfElseTest extends Tests {
 		  		"		c--;" + nl +
 		  		"	}/*/CIERRA else DE LINEA 5/*/" + nl +
 		  		"}/*/CIERRA main() DE LINEA 1/*/" + nl;
-		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS);
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");
 	}
 }

--- a/simae/src/test/java/simae/lib/cPlusPlus/IfTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/IfTest.java
@@ -22,7 +22,7 @@ class IfTest extends Tests {
 		  		"		c++;" + nl +
 		  		"	}/*/CIERRA if(c == 1) DE LINEA 2/*/" + nl +
 		  		"}/*/CIERRA main() DE LINEA 1/*/" + nl;
-		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS);
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");
 	}
 }

--- a/simae/src/test/java/simae/lib/cPlusPlus/MainVacioTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/MainVacioTest.java
@@ -15,7 +15,7 @@ class MainVacioTest extends Tests {
 		  prog = "int main() {" + nl + "}" + nl;
 		  esperado = "int main()/*/CIERRA EN LINEA 2/*/ {" + nl +
 		  		"}/*/CIERRA main() DE LINEA 1/*/" + nl;
-		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS);
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");
 	}
 }

--- a/simae/src/test/java/simae/lib/cPlusPlus/PreprocesadorTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/PreprocesadorTest.java
@@ -19,7 +19,7 @@ class PreprocesadorTest extends Tests{
 		 		"	while(c)/*/CIERRA EN LINEA 3/*/ if(c)/*/CIERRA EN LINEA 3/*/ {" + nl +
 		 		"	}/*/CIERRA if(c) DE LINEA 2 y CIERRA while(c) DE LINEA 2/*/" + nl + 
 		 		"}/*/CIERRA main() DE LINEA 1/*/" + nl; 
-		 marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS);
+		 marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "es");
 		 assertEquals(esperado,marcado, "No son iguales.");
 	}
 

--- a/simae/src/test/java/simae/lib/cPlusPlus/SwitchTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/SwitchTest.java
@@ -22,7 +22,7 @@ class SwitchTest extends Tests {
 			  		"" + nl +
 			  		"	}/*/CIERRA switch(c) DE LINEA 2/*/" + nl + 
 			  		"}/*/CIERRA main() DE LINEA 1/*/" + nl;
-		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS);
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");
 	}
 }

--- a/simae/src/test/java/simae/lib/cPlusPlus/WhileTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/WhileTest.java
@@ -22,7 +22,7 @@ class WhileTest extends Tests {
 			  		"		c++;" + nl +
 			  		"	}/*/CIERRA while(c>0) DE LINEA 2/*/" + nl +
 			  		"}/*/CIERRA main() DE LINEA 1/*/" + nl;
-		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS);
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");
 	}
 }

--- a/simae/src/test/java/simae/lib/java8/ClassTest.java
+++ b/simae/src/test/java/simae/lib/java8/ClassTest.java
@@ -20,7 +20,7 @@ class ClassTest extends Tests {
 		  esperado = "public class Main /*/CIERRA EN LINEA 3/*/{\n" +
 				  "\n" +
 				  "}/*/CIERRA class Main DE LINEA 1/*/\n";
-		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.JAVA8);
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.JAVA8, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");
 	}
 }

--- a/simae/src/test/java/simae/lib/java8/DoWhileTest.java
+++ b/simae/src/test/java/simae/lib/java8/DoWhileTest.java
@@ -33,7 +33,7 @@ class DoWhileTest extends Tests {
 				  "		} while (i <= 10);/*/CIERRA do while DE LINEA 4/*/\n" +
 				  "	}/*/CIERRA void main(String[] args) DE LINEA 2/*/\n" +
 				  "}/*/CIERRA class Main DE LINEA 1/*/\n";
-		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.JAVA8);
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.JAVA8, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");
 	}
 }

--- a/simae/src/test/java/simae/lib/java8/ForTest.java
+++ b/simae/src/test/java/simae/lib/java8/ForTest.java
@@ -30,7 +30,7 @@ class ForTest extends Tests {
 				  "      	}/*/CIERRA for(int i=0; i<10; i++) DE LINEA 4/*/\n" +
 				  "      }/*/CIERRA void main(String[] args) DE LINEA 2/*/\n" +
 				  "}/*/CIERRA class Main DE LINEA 1/*/\n";
-		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.JAVA8);
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.JAVA8, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");
 	}
 }

--- a/simae/src/test/java/simae/lib/java8/IfElseSinLlavesTest.java
+++ b/simae/src/test/java/simae/lib/java8/IfElseSinLlavesTest.java
@@ -1,0 +1,36 @@
+package simae.lib.java8;
+
+import org.junit.jupiter.api.Test;
+import simae.SimaeLauncher;
+import simae.lib.Lenguaje;
+import simae.lib.cPlusPlus.Tests;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class IfElseSinLlavesTest extends Tests {
+
+	
+	@Test
+	void ifElseTest() throws IOException {
+		  prog = "public class Main {\n" +
+				  "    public static void main(String[] args) {\n" +
+				  "        if (esPar(numero)) \n" +
+				  "            System.out.println(\"El número es par\");\n" +
+				  "        else\n" +
+				  "            System.out.println(\"El número es impar\");\n" +
+				  "    }\n" +
+				  "}\n";
+		  esperado = "public class Main /*/CIERRA EN LINEA 8/*/{\n" +
+				  "    public static void main(String[] args)/*/CIERRA EN LINEA 7/*/ {\n" +
+				  "        if (esPar(numero))/*/CIERRA EN LINEA 4/*/ \n" +
+				  "            System.out.println(\"El número es par\");/*/CIERRA if (esPar(numero)) DE LINEA 3/*/\n" +
+				  "        else/*/CIERRA EN LINEA 6/*/\n" +
+				  "            System.out.println(\"El número es impar\");/*/CIERRA else DE LINEA 5/*/\n" +
+				  "    }/*/CIERRA void main(String[] args) DE LINEA 2/*/\n" +
+				  "}/*/CIERRA class Main DE LINEA 1/*/\n";
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.JAVA8, "es");
+		  assertEquals(esperado,marcado, "No son iguales.");
+	}
+}

--- a/simae/src/test/java/simae/lib/java8/IfElseTest.java
+++ b/simae/src/test/java/simae/lib/java8/IfElseTest.java
@@ -27,14 +27,14 @@ class IfElseTest extends Tests {
 		  esperado = "public class Main /*/CIERRA EN LINEA 10/*/{\n" +
 				  "      public static void main(String[] args)/*/CIERRA EN LINEA 9/*/ {\n" +
 				  "      	int k = 1;\n" +
-				  "      	if(k == 1){\n" +
+				  "      	if(k == 1)/*/CIERRA EN LINEA 6/*/{\n" +
 				  "      		k++;\n" +
 				  "      	}/*/CIERRA if(k == 1) DE LINEA 4/*/ else/*/CIERRA EN LINEA 8/*/ {\n" +
 				  "      		k--;\n" +
 				  "      	}/*/CIERRA else DE LINEA 6/*/\n" +
 				  "      }/*/CIERRA void main(String[] args) DE LINEA 2/*/\n" +
 				  "}/*/CIERRA class Main DE LINEA 1/*/\n";
-		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.JAVA8);
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.JAVA8, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");
 	}
 }

--- a/simae/src/test/java/simae/lib/java8/IfTest.java
+++ b/simae/src/test/java/simae/lib/java8/IfTest.java
@@ -34,7 +34,7 @@ class IfTest extends Tests {
 				  "        }/*/CIERRA if (c == 5) DE LINEA 5/*/\n" +
 				  "    }/*/CIERRA void main(String[] args) DE LINEA 3/*/\n" +
 				  "}/*/CIERRA class Main DE LINEA 1/*/\n";
-		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.JAVA8);
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.JAVA8, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");
 	}
 }

--- a/simae/src/test/java/simae/lib/java8/MethodTest.java
+++ b/simae/src/test/java/simae/lib/java8/MethodTest.java
@@ -36,7 +36,7 @@ class MethodTest extends Tests {
 				  "    }/*/CIERRA void main(String[] args) DE LINEA 7/*/\n" +
 				  "    \n" +
 				  "}/*/CIERRA class Main DE LINEA 1/*/\n";
-		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.JAVA8);
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.JAVA8, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");
 	}
 }

--- a/simae/src/test/java/simae/lib/java8/SwitchTest.java
+++ b/simae/src/test/java/simae/lib/java8/SwitchTest.java
@@ -42,7 +42,7 @@ class SwitchTest extends Tests {
 				  "        }/*/CIERRA switch (c) DE LINEA 5/*/\n" +
 				  "    }/*/CIERRA void main(String[] args) DE LINEA 3/*/\n" +
 				  "}/*/CIERRA class Main DE LINEA 1/*/\n";
-		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.JAVA8);
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.JAVA8, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");
 	}
 }

--- a/simae/src/test/java/simae/lib/java8/WhileTest.java
+++ b/simae/src/test/java/simae/lib/java8/WhileTest.java
@@ -30,7 +30,7 @@ class WhileTest extends Tests {
 				  "      	}/*/CIERRA while(k<10) DE LINEA 4/*/\n" +
 				  "      }/*/CIERRA void main(String[] args) DE LINEA 2/*/\n" +
 				  "}/*/CIERRA class Main DE LINEA 1/*/\n";
-		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.JAVA8);
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.JAVA8, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");
 	}
 }

--- a/simae/src/test/java/simae/lib/python/ClassTest.java
+++ b/simae/src/test/java/simae/lib/python/ClassTest.java
@@ -18,7 +18,7 @@ class ClassTest extends Tests {
 				  "  x = 5" + nl;
 		  esperado = "class MyClass:# /CIERRA EN LINEA 2/\n" +
 				  "  x = 5# /CIERRA class MyClass DE LINEA 1/" + nl;
-		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.PYTHON3);
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.PYTHON3, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");
 	}
 }

--- a/simae/src/test/java/simae/lib/python/ForTest.java
+++ b/simae/src/test/java/simae/lib/python/ForTest.java
@@ -20,7 +20,7 @@ class ForTest extends Tests {
 		  esperado = "for x in students:# /CIERRA EN LINEA 2/" + nl +
 			  		"    print(\"x\")# /CIERRA for x in students DE LINEA 1/" + nl +
 			  		"print(\"print2\")" + nl;
-		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.PYTHON3);
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.PYTHON3, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");
 	}
 }

--- a/simae/src/test/java/simae/lib/python/IfElseTest.java
+++ b/simae/src/test/java/simae/lib/python/IfElseTest.java
@@ -21,8 +21,8 @@ class IfElseTest extends Tests {
 		  esperado = "if(p==1):# /CIERRA EN LINEA 2/" + nl +
 				  "	p=0# /CIERRA if(p==1) DE LINEA 1/" + nl +
 				  "else:# /CIERRA EN LINEA 4/" + nl +
-				  "	p=1# /CIERRA else DE LÍNEA 3/" +nl;
-		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.PYTHON3);
+				  "	p=1# /CIERRA else DE LINEA 3/" +nl;
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.PYTHON3, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");
 	}
 }

--- a/simae/src/test/java/simae/lib/python/IfTest.java
+++ b/simae/src/test/java/simae/lib/python/IfTest.java
@@ -22,7 +22,7 @@ class IfTest extends Tests {
 				  "b = 200\n" +
 				  "if b > a:# /CIERRA EN LINEA 4/\n" +
 				  "  print(\"b is greater than a\")# /CIERRA if b > a DE LINEA 3/\n";
-		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.PYTHON3);
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.PYTHON3, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");
 	}
 }

--- a/simae/src/test/java/simae/lib/python/WhileTest.java
+++ b/simae/src/test/java/simae/lib/python/WhileTest.java
@@ -20,7 +20,7 @@ class WhileTest extends Tests {
 		  esperado = "while(c):# /CIERRA EN LINEA 2/" + nl +
 			  		"    print(\"print1\")# /CIERRA while(c) DE LINEA 1/" + nl +
 			  		"print(\"print2\")" + nl;
-		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.PYTHON3);
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.PYTHON3, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");
 	}
 }


### PR DESCRIPTION
* Resuelto warning que indicaba problemas de versiones entre JavaFX y Java en la consola cuando se abría la GUI.
* Resueltos problema de tests ejecutándose en sistemas operativos con lenguaje inglés.
* Hotfixes críticos en marcado de Java y Python.