### PR TITLE
Arregla orden de marcado y correciones de tests

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/simae-languages/src/main/antlr/simae/grammars/CPP14.g4
+++ b/simae-languages/src/main/antlr/simae/grammars/CPP14.g4
@@ -339,7 +339,6 @@ statement
    | attributespecifierseq? jumpstatement
    | declarationstatement
    | attributespecifierseq? tryblock
-   | elsestatement
    ;
 
 labeledstatement
@@ -363,6 +362,7 @@ statementseq
 
 selectionstatement
    : If '(' condition ')' statement					# IfStatement
+   | If '(' condition ')' statement elsestatement	# IfElseStatement
    | Switch '(' condition ')' statement				# SwitchStatement
    ;
 

--- a/simae-languages/src/main/antlr/simae/grammars/JavaParser.g4
+++ b/simae-languages/src/main/antlr/simae/grammars/JavaParser.g4
@@ -388,7 +388,7 @@ statement
     : blockLabel=block                                                      # BlockLabelStatement
     | ASSERT expression (':' expression)? ';'                               # AssertStatement
     | IF parExpression statement                                            # IfStatement
-    | ELSE statement                                                        # ElseStatement
+    | IF parExpression statement elseStatement                              # IfElseStatement
     | FOR '(' forControl ')' statement                                      # ForStatement
     | WHILE parExpression statement                                         # WhileStatement
     | DO statement WHILE parExpression ';'                                  # DoWhileStatement
@@ -405,6 +405,9 @@ statement
     | identifierLabel=IDENTIFIER ':' statement                              # IdentifierStatement
     ;
 
+elseStatement
+    : ELSE statement
+    ;
 
 catchClause
     : CATCH '(' variableModifier* catchType IDENTIFIER ')' block

--- a/simae/src/main/java/simae/languages/Interfaz_en.java
+++ b/simae/src/main/java/simae/languages/Interfaz_en.java
@@ -10,6 +10,7 @@ public class Interfaz_en extends ListResourceBundle {
                     {"endsOn", "CLOSES ON LINE "},
                     {"closes", "CLOSES "},
                     {"ofLine", " OF LINE "},
+                    {"and", " and "},
                     //Descripcion de argumentos
                     {"language", "Language used for tagging and messages"},
                     {"untag", "Removes SIMAE tags from <inputFile>"},
@@ -36,7 +37,6 @@ public class Interfaz_en extends ListResourceBundle {
                     {"missingResource", "The entered language is not available."},
                     {"overwritten1", "The option "},
                     {"overwritten2", " should be specified only once.\n"},
-
 
 
             };

--- a/simae/src/main/java/simae/languages/Interfaz_es.java
+++ b/simae/src/main/java/simae/languages/Interfaz_es.java
@@ -11,6 +11,7 @@ public class Interfaz_es extends ListResourceBundle {
                     {"endsOn", "CIERRA EN LINEA "},
                     {"closes", "CIERRA "},
                     {"ofLine", " DE LINEA "},
+                    {"and", " y "},
                    //Descripcion de argumentos
                     {"language", "Idioma utilizado para el marcado y mensajes"},
                     {"input", "Archivo de entrada"},

--- a/simae/src/main/java/simae/lib/Simae.java
+++ b/simae/src/main/java/simae/lib/Simae.java
@@ -21,14 +21,9 @@ import javax.sound.sampled.AudioSystem;
 import javax.sound.sampled.Clip;
 
 public class Simae {
-	
-	//FIXME: reestructurar funcion para que no solo funcione con translationunit
-	private static List<AnotacionMarca> iniciaTranslationUnit(CharStream antlrEntrada, Lenguaje lenguaje, String language) {
-		StringTags st;
-		HashMap<String, String> strings;
 
-		st = new StringTags((language != null) ? language : "");
-		strings = st.getStrings();
+	//FIXME: reestructurar funcion para que no solo funcione con translationunit
+	private static List<AnotacionMarca> iniciaTranslationUnit(CharStream antlrEntrada, Lenguaje lenguaje, String language, HashMap<String, String> strings) {
 
 		Lexer lexer = ANTLRFactory.getLexer(lenguaje, antlrEntrada);
 		CommonTokenStream tokens = new CommonTokenStream(lexer);
@@ -62,7 +57,7 @@ public class Simae {
 
 	}
 
-	private static void algoritmoMarcado(BufferedReader brPreprocesado, PrintWriter pw, List<AnotacionMarca> todasMarcas) throws IOException {
+	private static void algoritmoMarcado(BufferedReader brPreprocesado, PrintWriter pw, List<AnotacionMarca> todasMarcas, HashMap<String, String> strings) throws IOException {
 
 		/*
 		 * Se recorre la lista de marcas
@@ -106,8 +101,7 @@ public class Simae {
 			while (marcaSiguiente != null) {
 				if (nroFila != marcaSiguiente.getFila()
 						|| posEnFila != marcaSiguiente.getPosicion()) break;
-
-				pw.print(" y " + marcaSiguiente.getMarca());
+				pw.print(strings.get("and") + marcaSiguiente.getMarca());
 				marcaSiguiente = it.hasNext() ? it.next() : null;
 			}
 			pw.print(marca.getFinComentario());
@@ -130,10 +124,13 @@ public class Simae {
 		CharStream antlrEntrada = CharStreams.fromString(armaCompleto);
 		
 		BufferedReader brPreprocesado = new BufferedReader(new StringReader(armaCompleto));
-		
-		List<AnotacionMarca> todasMarcas = iniciaTranslationUnit(antlrEntrada, programmingLanguage, language);
 
-        algoritmoMarcado(brPreprocesado, pw, todasMarcas);
+		StringTags st = new StringTags((language != null) ? language : "");
+		HashMap<String, String> strings = st.getStrings();
+
+		List<AnotacionMarca> todasMarcas = iniciaTranslationUnit(antlrEntrada, programmingLanguage, language, strings);
+
+        algoritmoMarcado(brPreprocesado, pw, todasMarcas, strings);
 
 	}
 

--- a/simae/src/main/java/simae/lib/Simae.java
+++ b/simae/src/main/java/simae/lib/Simae.java
@@ -79,7 +79,7 @@ public class Simae {
 
 		entrada = brPreprocesado.readLine();
 		int posEnFila = 0;
-		Collections.sort(todasMarcas);
+		//Collections.sort(todasMarcas);
 		Iterator<AnotacionMarca> it = todasMarcas.iterator();
 		AnotacionMarca marca;
 		AnotacionMarca marcaSiguiente = null;

--- a/simae/src/main/java/simae/lib/listener/CPPListener.java
+++ b/simae/src/main/java/simae/lib/listener/CPPListener.java
@@ -125,7 +125,17 @@ public class CPPListener extends CPP14BaseListener {
 	
 	@Override
 	public void enterElsestatement(CPP14Parser.ElsestatementContext ctx) {
-		String texto = strings.get("closes") + "EN LINEA " + ctx.statement().getStop().getLine();
+		CPP14Parser.IfElseStatementContext ifElse = (CPP14Parser.IfElseStatementContext) ctx.getParent();
+
+		String ifCompleto = getOriginalCode(ifElse.getStart(), ifElse.condition().getStop());
+		String textoIf = strings.get("closes") + ifCompleto + strings.get("ofLine") + ifElse.getStart().getLine();
+
+		marcas.add(new AnotacionMarca(ifElse.statement().getStop().getLine(),
+				ifElse.statement().getStop().getCharPositionInLine(),
+				textoIf));
+
+
+		String texto = strings.get("endsOn") + ctx.statement().getStop().getLine();
 		Token elseT = (Token)ctx.getChild(ctx.getChildCount() - 2).getPayload();
 	    marcas.add(new AnotacionMarca(elseT.getLine(),
 	    						  elseT.getCharPositionInLine() + 3,
@@ -142,7 +152,17 @@ public class CPPListener extends CPP14BaseListener {
                                       ctx.getStop().getCharPositionInLine(),
                                       texto));		
 	}
-	
+
+	@Override
+	public void enterIfElseStatement(CPP14Parser.IfElseStatementContext ctx) {
+		//If '(' condition ')' statement elsestatement
+		String texto = strings.get("endsOn") + ctx.statement().getStop().getLine();
+		Token parentesis = (Token)ctx.getChild(ctx.getChildCount() - 3).getPayload();
+		marcas.add(new AnotacionMarca(parentesis.getLine(),
+				parentesis.getCharPositionInLine(),
+				texto));
+	}
+
 	@Override
 	public void exitWhileStatement(CPP14Parser.WhileStatementContext ctx) {
 		//While '(' condition ')' statement

--- a/simae/src/main/java/simae/lib/listener/JavaListener.java
+++ b/simae/src/main/java/simae/lib/listener/JavaListener.java
@@ -140,10 +140,29 @@ public class JavaListener extends JavaParserBaseListener {
 	}
 
 	@Override
-	public void enterElseStatement(JavaParser.ElseStatementContext ctx) {
-		//ELSE statement;
+	public void enterIfElseStatement(JavaParser.IfElseStatementContext ctx) {
+		//IF parExpression statement elseStatement
 		String texto = strings.get("endsOn") + ctx.statement().getStop().getLine();
-		Token elseT = (Token)ctx.getChild(ctx.getChildCount() - 2).getPayload();
+		Token parentesis = ctx.parExpression().getStop();
+		marcas.add(new AnotacionMarca(parentesis.getLine(),
+				parentesis.getCharPositionInLine(),
+				texto));
+	}
+
+	@Override
+	public void enterElseStatement(JavaParser.ElseStatementContext ctx) {
+		JavaParser.IfElseStatementContext ifElse = (JavaParser.IfElseStatementContext) ctx.getParent();
+
+		String ifCompleto = getOriginalCode(ifElse.getStart(), ifElse.parExpression().getStop());
+		String textoIf = strings.get("closes") + ifCompleto + strings.get("ofLine") + ifElse.getStart().getLine();
+
+		marcas.add(new AnotacionMarca(ifElse.statement().getStop().getLine(),
+				ifElse.statement().getStop().getCharPositionInLine(),
+				textoIf));
+
+
+		String texto = strings.get("endsOn") + ctx.statement().getStop().getLine();
+		Token elseT = (Token) ctx.getChild(ctx.getChildCount() - 2).getPayload();
 		marcas.add(new AnotacionMarca(elseT.getLine(),
 				elseT.getCharPositionInLine() + 3,
 				texto));

--- a/simae/src/main/java/simae/lib/listener/StringTags.java
+++ b/simae/src/main/java/simae/lib/listener/StringTags.java
@@ -24,6 +24,7 @@ public class StringTags {
         strings.put("endsOn", (String) rb.getObject("endsOn"));
         strings.put("closes", (String) rb.getObject("closes"));
         strings.put("ofLine", (String) rb.getObject("ofLine"));
+        strings.put("and", (String) rb.getObject("and"));
     }
 
     public HashMap<String, String> getStrings() {

--- a/simae/src/test/java/simae/lib/cPlusPlus/en/ArchivoConDeclaracionDeDosVariablesTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/en/ArchivoConDeclaracionDeDosVariablesTest.java
@@ -1,0 +1,24 @@
+package simae.lib.cPlusPlus.en;
+
+import org.junit.jupiter.api.Test;
+import simae.SimaeLauncher;
+import simae.lib.Lenguaje;
+import simae.lib.cPlusPlus.es.Tests;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ArchivoConDeclaracionDeDosVariablesTest extends Tests {
+
+	@Test
+	void testArchivoConDeclaracionDeDosVariablesTest() throws IOException {
+		prog = "int a = 4;" + nl +
+				 "int b = 4;";
+		 esperado = "int a = 4;" + nl +
+				 	"int b = 4;" + nl; 
+		 marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "en");
+		 assertEquals(esperado,marcado, "The expected code and the result are not equals.");
+	}
+
+}

--- a/simae/src/test/java/simae/lib/cPlusPlus/en/ArchivoConDeclaracionDeVariableTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/en/ArchivoConDeclaracionDeVariableTest.java
@@ -1,0 +1,23 @@
+package simae.lib.cPlusPlus.en;
+
+import org.junit.jupiter.api.Test;
+import simae.SimaeLauncher;
+import simae.lib.Lenguaje;
+import simae.lib.cPlusPlus.es.Tests;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ArchivoConDeclaracionDeVariableTest extends Tests {
+
+	@Test
+	void testArchivoConDeclaracionDeVariableTest() throws IOException {
+		 
+		 prog = "int a = 4;" + nl;
+		 esperado = "int a = 4;" + nl;
+		 marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "en");
+		 assertEquals(esperado,marcado, "The expected code and the result are not equals.");
+	}
+
+}

--- a/simae/src/test/java/simae/lib/cPlusPlus/en/ClassTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/en/ClassTest.java
@@ -1,0 +1,30 @@
+package simae.lib.cPlusPlus.en;
+
+import org.junit.jupiter.api.Test;
+import simae.SimaeLauncher;
+import simae.lib.Lenguaje;
+import simae.lib.cPlusPlus.es.Tests;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ClassTest extends Tests {
+
+	
+	@Test
+	void testClass() throws IOException {
+		  prog = "class CRender {" + nl +
+				  "public:" + nl +
+				  "    char buffer[255];" + nl +
+				  "    void llamadoFuncion(const char *argumento);" + nl +
+				  "};" + nl;
+		  esperado = "class CRender /*/CLOSES ON LINE 5/*/{" + nl +
+				  "public:" + nl +
+ 				  "    char buffer[255];" + nl +
+				  "    void llamadoFuncion(const char *argumento);" + nl +
+				  "}/*/CLOSES class CRender  OF LINE 1/*/;" + nl;
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "en");
+		  assertEquals(esperado,marcado, "The expected code and the result are not equals.");
+	}
+}

--- a/simae/src/test/java/simae/lib/cPlusPlus/en/DoWhileTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/en/DoWhileTest.java
@@ -1,0 +1,29 @@
+package simae.lib.cPlusPlus.en;
+
+import org.junit.jupiter.api.Test;
+import simae.SimaeLauncher;
+import simae.lib.Lenguaje;
+import simae.lib.cPlusPlus.es.Tests;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DoWhileTest extends Tests {
+
+	
+	@Test
+	void testDoWhile() throws IOException {
+		  prog = "int main() {" + nl +
+		  		"	do {" + nl +
+		  		"	} while(c<0);" + nl +
+		  		"}" + nl;
+		  esperado = "int main()/*/CLOSES ON LINE 4/*/ {" + nl +
+		  		"	do/*/CLOSES ON LINE 3/*/ {" + nl +
+		  		"	} while(c<0);/*/CLOSES do while OF LINE 2/*/" + nl +
+		  		"}/*/CLOSES main() OF LINE 1/*/" + nl;
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "en");
+
+		  assertEquals(esperado,marcado, "The expected code and the result are not equals.");
+	}
+}

--- a/simae/src/test/java/simae/lib/cPlusPlus/en/ForEachTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/en/ForEachTest.java
@@ -1,0 +1,30 @@
+package simae.lib.cPlusPlus.en;
+
+import org.junit.jupiter.api.Test;
+import simae.SimaeLauncher;
+import simae.lib.Lenguaje;
+import simae.lib.cPlusPlus.es.Tests;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ForEachTest extends Tests {
+
+	
+	@Test
+	void testForEach() throws IOException {
+		  prog = "int main() {" + nl +
+		  		"	for(int it : vector) {" + nl +
+		  		"		c++;" + nl +
+		  		"	}" + nl +
+		  		"}" + nl;
+		  esperado = "int main()/*/CLOSES ON LINE 5/*/ {" + nl +
+		  		"	for(int it : vector)/*/CLOSES ON LINE 4/*/ {" + nl +
+		  		"		c++;" + nl +
+		  		"	}/*/CLOSES for(int it : vector) OF LINE 2/*/" + nl +
+		  		"}/*/CLOSES main() OF LINE 1/*/" + nl;
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "en");
+		  assertEquals(esperado,marcado, "The expected code and the result are not equals.");
+	}
+}

--- a/simae/src/test/java/simae/lib/cPlusPlus/en/ForTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/en/ForTest.java
@@ -1,0 +1,31 @@
+package simae.lib.cPlusPlus.en;
+
+import org.junit.jupiter.api.Test;
+import simae.SimaeLauncher;
+import simae.lib.Lenguaje;
+import simae.lib.cPlusPlus.es.Tests;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ForTest extends Tests {
+
+	
+	@Test
+	void testFor() throws IOException {
+		  prog = "int main() {" + nl +
+		  		"	for(int i = 0; i<10; i++) {" + nl +
+		  		"		c++;" + nl +
+		  		"	}" + nl +
+		  		"}" + nl +
+		  		"";
+		  esperado = "int main()/*/CLOSES ON LINE 5/*/ {" + nl +
+			  		"	for(int i = 0; i<10; i++)/*/CLOSES ON LINE 4/*/ {" + nl +
+			  		"		c++;" + nl +
+			  		"	}/*/CLOSES for(int i = 0; i<10; i++) OF LINE 2/*/" + nl +
+			  		"}/*/CLOSES main() OF LINE 1/*/" + nl;
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "en");
+		  assertEquals(esperado,marcado, "The expected code and the result are not equals.");
+	}
+}

--- a/simae/src/test/java/simae/lib/cPlusPlus/en/IfElseTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/en/IfElseTest.java
@@ -1,0 +1,36 @@
+package simae.lib.cPlusPlus.en;
+
+import org.junit.jupiter.api.Test;
+import simae.SimaeLauncher;
+import simae.lib.Lenguaje;
+import simae.lib.cPlusPlus.es.Tests;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class IfElseTest extends Tests {
+
+	
+	@Test
+	void testIfElse() throws IOException {
+		  prog = "int main() {" + nl +
+		  		"	if(c == 1) {" + nl +
+		  		"		c++;" + nl +
+		  		"	}" + nl +
+		  		"	else {" + nl +
+		  		"		c--;" + nl +
+		  		"	}" + nl +
+		  		"}" + nl;
+		  esperado = "int main()/*/CLOSES ON LINE 8/*/ {" + nl +
+		  		"	if(c == 1)/*/CLOSES ON LINE 4/*/ {" + nl +
+		  		"		c++;" + nl +
+		  		"	}/*/CLOSES if(c == 1) OF LINE 2/*/" + nl +
+		  		"	else/*/CLOSES ON LINE 7/*/ {" + nl +
+		  		"		c--;" + nl +
+		  		"	}/*/CLOSES else OF LINE 5/*/" + nl +
+		  		"}/*/CLOSES main() OF LINE 1/*/" + nl;
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "en");
+		  assertEquals(esperado,marcado, "The expected code and the result are not equals.");
+	}
+}

--- a/simae/src/test/java/simae/lib/cPlusPlus/en/IfTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/en/IfTest.java
@@ -1,0 +1,30 @@
+package simae.lib.cPlusPlus.en;
+
+import org.junit.jupiter.api.Test;
+import simae.SimaeLauncher;
+import simae.lib.Lenguaje;
+import simae.lib.cPlusPlus.es.Tests;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class IfTest extends Tests {
+
+	
+	@Test
+	void testIf() throws IOException {
+		  prog = "int main() {" + nl +
+		  		"	if(c == 1) {" + nl +
+		  		"		c++;" + nl +
+		  		"	}" + nl +
+		  		"}" + nl;
+		  esperado = "int main()/*/CLOSES ON LINE 5/*/ {" + nl +
+		  		"	if(c == 1)/*/CLOSES ON LINE 4/*/ {" + nl +
+		  		"		c++;" + nl +
+		  		"	}/*/CLOSES if(c == 1) OF LINE 2/*/" + nl +
+		  		"}/*/CLOSES main() OF LINE 1/*/" + nl;
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "en");
+		  assertEquals(esperado,marcado, "The expected code and the result are not equals.");
+	}
+}

--- a/simae/src/test/java/simae/lib/cPlusPlus/en/PreprocesadorTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/en/PreprocesadorTest.java
@@ -1,0 +1,28 @@
+package simae.lib.cPlusPlus.en;
+
+import org.junit.jupiter.api.Test;
+import simae.SimaeLauncher;
+import simae.lib.Lenguaje;
+import simae.lib.cPlusPlus.es.Tests;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PreprocesadorTest extends Tests {
+
+	@Test
+	void preprocesadorTest() throws IOException {
+		prog = "int main()/*/CIERRA EN LINEA 6/*/ {\n" +
+				"	while(c)/*/CIERRA EN LINEA 4/*/ if(c)/*/CIERRA EN LINEA 4/*/ {\n" + 
+				"	}/*/CIERRA if(c) DE LINEA 3/*//*/CIERRA while(c) DE LINEA 3/*/\n" + 
+				"}/*/CIERRA main() DE LINEA 1/*/";
+		 esperado = "int main()/*/CLOSES ON LINE 4/*/ {" + nl +
+		 		"	while(c)/*/CLOSES ON LINE 3/*/ if(c)/*/CLOSES ON LINE 3/*/ {" + nl +
+		 		"	}/*/CLOSES if(c) OF LINE 2 and CLOSES while(c) OF LINE 2/*/" + nl +
+		 		"}/*/CLOSES main() OF LINE 1/*/" + nl;
+		 marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "en");
+		 assertEquals(esperado,marcado, "The expected code and the result are not equals.");
+	}
+
+}

--- a/simae/src/test/java/simae/lib/cPlusPlus/en/SwitchTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/en/SwitchTest.java
@@ -1,0 +1,30 @@
+package simae.lib.cPlusPlus.en;
+
+import org.junit.jupiter.api.Test;
+import simae.SimaeLauncher;
+import simae.lib.Lenguaje;
+import simae.lib.cPlusPlus.es.Tests;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SwitchTest extends Tests {
+
+	
+	@Test
+	void testSwitch() throws IOException {
+		  prog = "int main() {" + nl +
+		  		"	switch(c) {" + nl +
+		  		"" + nl +
+		  		"	}" + nl + 
+		  		"}" + nl;
+		  esperado = "int main()/*/CLOSES ON LINE 5/*/ {" + nl +
+			  		"	switch(c)/*/CLOSES ON LINE 4/*/ {" + nl +
+			  		"" + nl +
+			  		"	}/*/CLOSES switch(c) OF LINE 2/*/" + nl +
+			  		"}/*/CLOSES main() OF LINE 1/*/" + nl;
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "en");
+		  assertEquals(esperado,marcado, "The expected code and the result are not equals.");
+	}
+}

--- a/simae/src/test/java/simae/lib/cPlusPlus/en/WhileTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/en/WhileTest.java
@@ -1,0 +1,30 @@
+package simae.lib.cPlusPlus.en;
+
+import org.junit.jupiter.api.Test;
+import simae.SimaeLauncher;
+import simae.lib.Lenguaje;
+import simae.lib.cPlusPlus.es.Tests;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class WhileTest extends Tests {
+
+	
+	@Test
+	void testWhile() throws IOException {
+		  prog = "int main() {" + nl +
+		  		"	while(c>0) {" + nl +
+		  		"		c++;" + nl +
+		  		"	}" + nl +
+		  		"}" + nl;
+		  esperado = "int main()/*/CLOSES ON LINE 5/*/ {" + nl +
+			  		"	while(c>0)/*/CLOSES ON LINE 4/*/ {" + nl +
+			  		"		c++;" + nl +
+			  		"	}/*/CLOSES while(c>0) OF LINE 2/*/" + nl +
+			  		"}/*/CLOSES main() OF LINE 1/*/" + nl;
+		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "en");
+		  assertEquals(esperado,marcado, "The expected code and the result are not equals.");
+	}
+}

--- a/simae/src/test/java/simae/lib/cPlusPlus/es/ArchivoConDeclaracionDeDosVariablesTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/es/ArchivoConDeclaracionDeDosVariablesTest.java
@@ -1,4 +1,4 @@
-package simae.lib.cPlusPlus;
+package simae.lib.cPlusPlus.es;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;

--- a/simae/src/test/java/simae/lib/cPlusPlus/es/ArchivoConDeclaracionDeVariableTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/es/ArchivoConDeclaracionDeVariableTest.java
@@ -1,4 +1,4 @@
-package simae.lib.cPlusPlus;
+package simae.lib.cPlusPlus.es;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
@@ -7,14 +7,13 @@ import org.junit.jupiter.api.Test;
 import simae.SimaeLauncher;
 import simae.lib.Lenguaje;
 
-class ArchivoConIncludeTest extends Tests{
+class ArchivoConDeclaracionDeVariableTest extends Tests{
 
 	@Test
-	void testArchivoConIncludeTest() throws IOException {
-		 prog = "#include <iostream>" + nl +
-				 "int a = 4;" + nl;
-		 esperado = "#include <iostream>" + nl +
-				 	"int a = 4;" + nl;
+	void testArchivoConDeclaracionDeVariableTest() throws IOException {
+		 
+		 prog = "int a = 4;" + nl;
+		 esperado = "int a = 4;" + nl;
 		 marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "es");
 		 assertEquals(esperado,marcado, "No son iguales.");
 	}

--- a/simae/src/test/java/simae/lib/cPlusPlus/es/ArchivoConIncludeTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/es/ArchivoConIncludeTest.java
@@ -1,4 +1,4 @@
-package simae.lib.cPlusPlus;
+package simae.lib.cPlusPlus.es;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
@@ -7,13 +7,14 @@ import org.junit.jupiter.api.Test;
 import simae.SimaeLauncher;
 import simae.lib.Lenguaje;
 
-class ArchivoConDeclaracionDeVariableTest extends Tests{
+class ArchivoConIncludeTest extends Tests{
 
 	@Test
-	void testArchivoConDeclaracionDeVariableTest() throws IOException {
-		 
-		 prog = "int a = 4;" + nl;
-		 esperado = "int a = 4;" + nl;
+	void testArchivoConIncludeTest() throws IOException {
+		 prog = "#include <iostream>" + nl +
+				 "int a = 4;" + nl;
+		 esperado = "#include <iostream>" + nl +
+				 	"int a = 4;" + nl;
 		 marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "es");
 		 assertEquals(esperado,marcado, "No son iguales.");
 	}

--- a/simae/src/test/java/simae/lib/cPlusPlus/es/ClassTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/es/ClassTest.java
@@ -1,4 +1,4 @@
-package simae.lib.cPlusPlus;
+package simae.lib.cPlusPlus.es;
 
 import org.junit.jupiter.api.Test;
 import simae.SimaeLauncher;
@@ -12,7 +12,7 @@ class ClassTest extends Tests {
 
 	
 	@Test
-	void testIf() throws IOException {
+	void testClass() throws IOException {
 		  prog = "class CRender {" + nl +
 				  "public:" + nl +
 				  "    char buffer[255];" + nl +

--- a/simae/src/test/java/simae/lib/cPlusPlus/es/DoWhileTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/es/DoWhileTest.java
@@ -1,4 +1,4 @@
-package simae.lib.cPlusPlus;
+package simae.lib.cPlusPlus.es;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;

--- a/simae/src/test/java/simae/lib/cPlusPlus/es/DosMarcasJuntasTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/es/DosMarcasJuntasTest.java
@@ -1,4 +1,4 @@
-package simae.lib.cPlusPlus;
+package simae.lib.cPlusPlus.es;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;

--- a/simae/src/test/java/simae/lib/cPlusPlus/es/ForConComentarioTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/es/ForConComentarioTest.java
@@ -1,4 +1,4 @@
-package simae.lib.cPlusPlus;
+package simae.lib.cPlusPlus.es;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
@@ -7,21 +7,21 @@ import org.junit.jupiter.api.Test;
 import simae.SimaeLauncher;
 import simae.lib.Lenguaje;
 
-class ForTest extends Tests {
+class ForConComentarioTest extends Tests {
 
 	
 	@Test
-	void testFor() throws IOException {
+	void testForConComentario() throws IOException {
 		  prog = "int main() {" + nl +
-		  		"	for(int i = 0; i<10; i++) {" + nl +
+		  		"	for(int i = 0; /*Soy un comentario*/ i<   10; i++) {" + nl +
 		  		"		c++;" + nl +
 		  		"	}" + nl +
 		  		"}" + nl +
 		  		"";
 		  esperado = "int main()/*/CIERRA EN LINEA 5/*/ {" + nl + 
-			  		"	for(int i = 0; i<10; i++)/*/CIERRA EN LINEA 4/*/ {" + nl +
+			  		"	for(int i = 0; /*Soy un comentario*/ i<   10; i++)/*/CIERRA EN LINEA 4/*/ {" + nl +
 			  		"		c++;" + nl +
-			  		"	}/*/CIERRA for(int i = 0; i<10; i++) DE LINEA 2/*/" + nl +
+			  		"	}/*/CIERRA for(int i = 0; i< 10; i++) DE LINEA 2/*/" + nl +
 			  		"}/*/CIERRA main() DE LINEA 1/*/" + nl;
 		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");

--- a/simae/src/test/java/simae/lib/cPlusPlus/es/ForDosLineasConComentarioTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/es/ForDosLineasConComentarioTest.java
@@ -1,4 +1,4 @@
-package simae.lib.cPlusPlus;
+package simae.lib.cPlusPlus.es;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;

--- a/simae/src/test/java/simae/lib/cPlusPlus/es/ForDosLineasTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/es/ForDosLineasTest.java
@@ -1,4 +1,4 @@
-package simae.lib.cPlusPlus;
+package simae.lib.cPlusPlus.es;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
@@ -7,20 +7,22 @@ import org.junit.jupiter.api.Test;
 import simae.SimaeLauncher;
 import simae.lib.Lenguaje;
 
-class ForEachTest extends Tests {
+class ForDosLineasTest extends Tests {
 
 	
 	@Test
-	void testForEach() throws IOException {
+	void testForSeparado() throws IOException {
 		  prog = "int main() {" + nl +
-		  		"	for(int it : vector) {" + nl +
+		  		"	for(int i = 0;" + nl +
+		  		"			i<10; i++) {" + nl +
 		  		"		c++;" + nl +
 		  		"	}" + nl +
 		  		"}" + nl;
-		  esperado = "int main()/*/CIERRA EN LINEA 5/*/ {" + nl +
-		  		"	for(int it : vector)/*/CIERRA EN LINEA 4/*/ {" + nl + 
+		  esperado = "int main()/*/CIERRA EN LINEA 6/*/ {" + nl + 
+		  		"	for(int i = 0;" + nl +
+		  		"			i<10; i++)/*/CIERRA EN LINEA 5/*/ {" + nl +
 		  		"		c++;" + nl +
-		  		"	}/*/CIERRA for(int it : vector) DE LINEA 2/*/" + nl + 
+		  		"	}/*/CIERRA for(int i = 0; i<10; i++) DE LINEA 2/*/" + nl +
 		  		"}/*/CIERRA main() DE LINEA 1/*/" + nl;
 		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");

--- a/simae/src/test/java/simae/lib/cPlusPlus/es/ForEachTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/es/ForEachTest.java
@@ -1,4 +1,4 @@
-package simae.lib.cPlusPlus;
+package simae.lib.cPlusPlus.es;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
@@ -7,22 +7,20 @@ import org.junit.jupiter.api.Test;
 import simae.SimaeLauncher;
 import simae.lib.Lenguaje;
 
-class ForDosLineasTest extends Tests {
+class ForEachTest extends Tests {
 
 	
 	@Test
-	void testForSeparado() throws IOException {
+	void testForEach() throws IOException {
 		  prog = "int main() {" + nl +
-		  		"	for(int i = 0;" + nl +
-		  		"			i<10; i++) {" + nl +
+		  		"	for(int it : vector) {" + nl +
 		  		"		c++;" + nl +
 		  		"	}" + nl +
 		  		"}" + nl;
-		  esperado = "int main()/*/CIERRA EN LINEA 6/*/ {" + nl + 
-		  		"	for(int i = 0;" + nl +
-		  		"			i<10; i++)/*/CIERRA EN LINEA 5/*/ {" + nl +
+		  esperado = "int main()/*/CIERRA EN LINEA 5/*/ {" + nl +
+		  		"	for(int it : vector)/*/CIERRA EN LINEA 4/*/ {" + nl + 
 		  		"		c++;" + nl +
-		  		"	}/*/CIERRA for(int i = 0; i<10; i++) DE LINEA 2/*/" + nl +
+		  		"	}/*/CIERRA for(int it : vector) DE LINEA 2/*/" + nl + 
 		  		"}/*/CIERRA main() DE LINEA 1/*/" + nl;
 		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");

--- a/simae/src/test/java/simae/lib/cPlusPlus/es/ForTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/es/ForTest.java
@@ -1,4 +1,4 @@
-package simae.lib.cPlusPlus;
+package simae.lib.cPlusPlus.es;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
@@ -7,21 +7,21 @@ import org.junit.jupiter.api.Test;
 import simae.SimaeLauncher;
 import simae.lib.Lenguaje;
 
-class ForConComentarioTest extends Tests {
+class ForTest extends Tests {
 
 	
 	@Test
-	void testForConComentario() throws IOException {
+	void testFor() throws IOException {
 		  prog = "int main() {" + nl +
-		  		"	for(int i = 0; /*Soy un comentario*/ i<   10; i++) {" + nl +
+		  		"	for(int i = 0; i<10; i++) {" + nl +
 		  		"		c++;" + nl +
 		  		"	}" + nl +
 		  		"}" + nl +
 		  		"";
 		  esperado = "int main()/*/CIERRA EN LINEA 5/*/ {" + nl + 
-			  		"	for(int i = 0; /*Soy un comentario*/ i<   10; i++)/*/CIERRA EN LINEA 4/*/ {" + nl +
+			  		"	for(int i = 0; i<10; i++)/*/CIERRA EN LINEA 4/*/ {" + nl +
 			  		"		c++;" + nl +
-			  		"	}/*/CIERRA for(int i = 0; i< 10; i++) DE LINEA 2/*/" + nl +
+			  		"	}/*/CIERRA for(int i = 0; i<10; i++) DE LINEA 2/*/" + nl +
 			  		"}/*/CIERRA main() DE LINEA 1/*/" + nl;
 		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");

--- a/simae/src/test/java/simae/lib/cPlusPlus/es/IfElseIfTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/es/IfElseIfTest.java
@@ -1,4 +1,4 @@
-package simae.lib.cPlusPlus;
+package simae.lib.cPlusPlus.es;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
@@ -6,16 +6,16 @@ import org.junit.jupiter.api.Test;
 import simae.SimaeLauncher;
 import simae.lib.Lenguaje;
 
-class IfElseTest extends Tests {
+class IfElseIfTest extends Tests {
 
 	
 	@Test
-	void testIfElse() throws IOException {
+	void testIfElseIf() throws IOException {
 		  prog = "int main() {" + nl +
 		  		"	if(c == 1) {" + nl +
 		  		"		c++;" + nl +
 		  		"	}" + nl +
-		  		"	else {" + nl +
+		  		"	else if(c) {" + nl +
 		  		"		c--;" + nl +
 		  		"	}" + nl +
 		  		"}" + nl;
@@ -23,9 +23,9 @@ class IfElseTest extends Tests {
 		  		"	if(c == 1)/*/CIERRA EN LINEA 4/*/ {" + nl +
 		  		"		c++;" + nl +
 		  		"	}/*/CIERRA if(c == 1) DE LINEA 2/*/" + nl +
-		  		"	else/*/CIERRA EN LINEA 7/*/ {" + nl +
+		  		"	else/*/CIERRA EN LINEA 7/*/ if(c)/*/CIERRA EN LINEA 7/*/ {" + nl +
 		  		"		c--;" + nl +
-		  		"	}/*/CIERRA else DE LINEA 5/*/" + nl +
+		  		"	}/*/CIERRA if(c) DE LINEA 5 y CIERRA else DE LINEA 5/*/" + nl +
 		  		"}/*/CIERRA main() DE LINEA 1/*/" + nl;
 		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");

--- a/simae/src/test/java/simae/lib/cPlusPlus/es/IfElseTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/es/IfElseTest.java
@@ -1,4 +1,4 @@
-package simae.lib.cPlusPlus;
+package simae.lib.cPlusPlus.es;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
@@ -6,16 +6,16 @@ import org.junit.jupiter.api.Test;
 import simae.SimaeLauncher;
 import simae.lib.Lenguaje;
 
-class IfElseIfTest extends Tests {
+class IfElseTest extends Tests {
 
 	
 	@Test
-	void testIfElseIf() throws IOException {
+	void testIfElse() throws IOException {
 		  prog = "int main() {" + nl +
 		  		"	if(c == 1) {" + nl +
 		  		"		c++;" + nl +
 		  		"	}" + nl +
-		  		"	else if(c) {" + nl +
+		  		"	else {" + nl +
 		  		"		c--;" + nl +
 		  		"	}" + nl +
 		  		"}" + nl;
@@ -23,9 +23,9 @@ class IfElseIfTest extends Tests {
 		  		"	if(c == 1)/*/CIERRA EN LINEA 4/*/ {" + nl +
 		  		"		c++;" + nl +
 		  		"	}/*/CIERRA if(c == 1) DE LINEA 2/*/" + nl +
-		  		"	else/*/CIERRA EN LINEA 7/*/ if(c)/*/CIERRA EN LINEA 7/*/ {" + nl +
+		  		"	else/*/CIERRA EN LINEA 7/*/ {" + nl +
 		  		"		c--;" + nl +
-		  		"	}/*/CIERRA if(c) DE LINEA 5 y CIERRA else DE LINEA 5/*/" + nl +
+		  		"	}/*/CIERRA else DE LINEA 5/*/" + nl +
 		  		"}/*/CIERRA main() DE LINEA 1/*/" + nl;
 		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");

--- a/simae/src/test/java/simae/lib/cPlusPlus/es/IfTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/es/IfTest.java
@@ -1,4 +1,4 @@
-package simae.lib.cPlusPlus;
+package simae.lib.cPlusPlus.es;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
@@ -7,21 +7,21 @@ import org.junit.jupiter.api.Test;
 import simae.SimaeLauncher;
 import simae.lib.Lenguaje;
 
-class WhileTest extends Tests {
+class IfTest extends Tests {
 
 	
 	@Test
-	void testWhile() throws IOException {
+	void testIf() throws IOException {
 		  prog = "int main() {" + nl +
-		  		"	while(c>0) {" + nl +
+		  		"	if(c == 1) {" + nl +
 		  		"		c++;" + nl +
 		  		"	}" + nl +
 		  		"}" + nl;
 		  esperado = "int main()/*/CIERRA EN LINEA 5/*/ {" + nl +
-			  		"	while(c>0)/*/CIERRA EN LINEA 4/*/ {" + nl +
-			  		"		c++;" + nl +
-			  		"	}/*/CIERRA while(c>0) DE LINEA 2/*/" + nl +
-			  		"}/*/CIERRA main() DE LINEA 1/*/" + nl;
+		  		"	if(c == 1)/*/CIERRA EN LINEA 4/*/ {" + nl +
+		  		"		c++;" + nl +
+		  		"	}/*/CIERRA if(c == 1) DE LINEA 2/*/" + nl +
+		  		"}/*/CIERRA main() DE LINEA 1/*/" + nl;
 		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");
 	}

--- a/simae/src/test/java/simae/lib/cPlusPlus/es/MainVacioTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/es/MainVacioTest.java
@@ -1,4 +1,4 @@
-package simae.lib.cPlusPlus;
+package simae.lib.cPlusPlus.es;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;

--- a/simae/src/test/java/simae/lib/cPlusPlus/es/PreprocesadorTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/es/PreprocesadorTest.java
@@ -1,4 +1,4 @@
-package simae.lib.cPlusPlus;
+package simae.lib.cPlusPlus.es;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;

--- a/simae/src/test/java/simae/lib/cPlusPlus/es/SwitchTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/es/SwitchTest.java
@@ -1,4 +1,4 @@
-package simae.lib.cPlusPlus;
+package simae.lib.cPlusPlus.es;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;

--- a/simae/src/test/java/simae/lib/cPlusPlus/es/Tests.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/es/Tests.java
@@ -1,4 +1,4 @@
-package simae.lib.cPlusPlus;
+package simae.lib.cPlusPlus.es;
 
 public abstract class Tests {
 	protected final String nl = System.lineSeparator();

--- a/simae/src/test/java/simae/lib/cPlusPlus/es/WhileTest.java
+++ b/simae/src/test/java/simae/lib/cPlusPlus/es/WhileTest.java
@@ -1,4 +1,4 @@
-package simae.lib.cPlusPlus;
+package simae.lib.cPlusPlus.es;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
@@ -7,21 +7,21 @@ import org.junit.jupiter.api.Test;
 import simae.SimaeLauncher;
 import simae.lib.Lenguaje;
 
-class IfTest extends Tests {
+class WhileTest extends Tests {
 
 	
 	@Test
-	void testIf() throws IOException {
+	void testWhile() throws IOException {
 		  prog = "int main() {" + nl +
-		  		"	if(c == 1) {" + nl +
+		  		"	while(c>0) {" + nl +
 		  		"		c++;" + nl +
 		  		"	}" + nl +
 		  		"}" + nl;
 		  esperado = "int main()/*/CIERRA EN LINEA 5/*/ {" + nl +
-		  		"	if(c == 1)/*/CIERRA EN LINEA 4/*/ {" + nl +
-		  		"		c++;" + nl +
-		  		"	}/*/CIERRA if(c == 1) DE LINEA 2/*/" + nl +
-		  		"}/*/CIERRA main() DE LINEA 1/*/" + nl;
+			  		"	while(c>0)/*/CIERRA EN LINEA 4/*/ {" + nl +
+			  		"		c++;" + nl +
+			  		"	}/*/CIERRA while(c>0) DE LINEA 2/*/" + nl +
+			  		"}/*/CIERRA main() DE LINEA 1/*/" + nl;
 		  marcado = SimaeLauncher.launchTagging(prog, Lenguaje.CPLUSPLUS, "es");
 		  assertEquals(esperado,marcado, "No son iguales.");
 	}

--- a/simae/src/test/java/simae/lib/java8/ClassTest.java
+++ b/simae/src/test/java/simae/lib/java8/ClassTest.java
@@ -3,7 +3,7 @@ package simae.lib.java8;
 import org.junit.jupiter.api.Test;
 import simae.SimaeLauncher;
 import simae.lib.Lenguaje;
-import simae.lib.cPlusPlus.Tests;
+import simae.lib.cPlusPlus.es.Tests;
 
 import java.io.IOException;
 

--- a/simae/src/test/java/simae/lib/java8/DoWhileTest.java
+++ b/simae/src/test/java/simae/lib/java8/DoWhileTest.java
@@ -3,7 +3,7 @@ package simae.lib.java8;
 import org.junit.jupiter.api.Test;
 import simae.SimaeLauncher;
 import simae.lib.Lenguaje;
-import simae.lib.cPlusPlus.Tests;
+import simae.lib.cPlusPlus.es.Tests;
 
 import java.io.IOException;
 

--- a/simae/src/test/java/simae/lib/java8/ForTest.java
+++ b/simae/src/test/java/simae/lib/java8/ForTest.java
@@ -3,7 +3,7 @@ package simae.lib.java8;
 import org.junit.jupiter.api.Test;
 import simae.SimaeLauncher;
 import simae.lib.Lenguaje;
-import simae.lib.cPlusPlus.Tests;
+import simae.lib.cPlusPlus.es.Tests;
 
 import java.io.IOException;
 

--- a/simae/src/test/java/simae/lib/java8/IfElseSinLlavesTest.java
+++ b/simae/src/test/java/simae/lib/java8/IfElseSinLlavesTest.java
@@ -3,7 +3,7 @@ package simae.lib.java8;
 import org.junit.jupiter.api.Test;
 import simae.SimaeLauncher;
 import simae.lib.Lenguaje;
-import simae.lib.cPlusPlus.Tests;
+import simae.lib.cPlusPlus.es.Tests;
 
 import java.io.IOException;
 

--- a/simae/src/test/java/simae/lib/java8/IfElseTest.java
+++ b/simae/src/test/java/simae/lib/java8/IfElseTest.java
@@ -3,7 +3,7 @@ package simae.lib.java8;
 import org.junit.jupiter.api.Test;
 import simae.SimaeLauncher;
 import simae.lib.Lenguaje;
-import simae.lib.cPlusPlus.Tests;
+import simae.lib.cPlusPlus.es.Tests;
 
 import java.io.IOException;
 

--- a/simae/src/test/java/simae/lib/java8/IfTest.java
+++ b/simae/src/test/java/simae/lib/java8/IfTest.java
@@ -3,7 +3,7 @@ package simae.lib.java8;
 import org.junit.jupiter.api.Test;
 import simae.SimaeLauncher;
 import simae.lib.Lenguaje;
-import simae.lib.cPlusPlus.Tests;
+import simae.lib.cPlusPlus.es.Tests;
 
 import java.io.IOException;
 

--- a/simae/src/test/java/simae/lib/java8/MethodTest.java
+++ b/simae/src/test/java/simae/lib/java8/MethodTest.java
@@ -3,7 +3,7 @@ package simae.lib.java8;
 import org.junit.jupiter.api.Test;
 import simae.SimaeLauncher;
 import simae.lib.Lenguaje;
-import simae.lib.cPlusPlus.Tests;
+import simae.lib.cPlusPlus.es.Tests;
 
 import java.io.IOException;
 

--- a/simae/src/test/java/simae/lib/java8/SwitchTest.java
+++ b/simae/src/test/java/simae/lib/java8/SwitchTest.java
@@ -3,7 +3,7 @@ package simae.lib.java8;
 import org.junit.jupiter.api.Test;
 import simae.SimaeLauncher;
 import simae.lib.Lenguaje;
-import simae.lib.cPlusPlus.Tests;
+import simae.lib.cPlusPlus.es.Tests;
 
 import java.io.IOException;
 

--- a/simae/src/test/java/simae/lib/java8/WhileTest.java
+++ b/simae/src/test/java/simae/lib/java8/WhileTest.java
@@ -3,7 +3,7 @@ package simae.lib.java8;
 import org.junit.jupiter.api.Test;
 import simae.SimaeLauncher;
 import simae.lib.Lenguaje;
-import simae.lib.cPlusPlus.Tests;
+import simae.lib.cPlusPlus.es.Tests;
 
 import java.io.IOException;
 

--- a/simae/src/test/java/simae/lib/python/ClassTest.java
+++ b/simae/src/test/java/simae/lib/python/ClassTest.java
@@ -3,7 +3,7 @@ package simae.lib.python;
 import org.junit.jupiter.api.Test;
 import simae.SimaeLauncher;
 import simae.lib.Lenguaje;
-import simae.lib.cPlusPlus.Tests;
+import simae.lib.cPlusPlus.es.Tests;
 
 import java.io.IOException;
 

--- a/simae/src/test/java/simae/lib/python/ForTest.java
+++ b/simae/src/test/java/simae/lib/python/ForTest.java
@@ -3,7 +3,7 @@ package simae.lib.python;
 import org.junit.jupiter.api.Test;
 import simae.SimaeLauncher;
 import simae.lib.Lenguaje;
-import simae.lib.cPlusPlus.Tests;
+import simae.lib.cPlusPlus.es.Tests;
 
 import java.io.IOException;
 

--- a/simae/src/test/java/simae/lib/python/IfElseTest.java
+++ b/simae/src/test/java/simae/lib/python/IfElseTest.java
@@ -3,7 +3,7 @@ package simae.lib.python;
 import org.junit.jupiter.api.Test;
 import simae.SimaeLauncher;
 import simae.lib.Lenguaje;
-import simae.lib.cPlusPlus.Tests;
+import simae.lib.cPlusPlus.es.Tests;
 
 import java.io.IOException;
 

--- a/simae/src/test/java/simae/lib/python/IfTest.java
+++ b/simae/src/test/java/simae/lib/python/IfTest.java
@@ -3,7 +3,7 @@ package simae.lib.python;
 import org.junit.jupiter.api.Test;
 import simae.SimaeLauncher;
 import simae.lib.Lenguaje;
-import simae.lib.cPlusPlus.Tests;
+import simae.lib.cPlusPlus.es.Tests;
 
 import java.io.IOException;
 

--- a/simae/src/test/java/simae/lib/python/WhileTest.java
+++ b/simae/src/test/java/simae/lib/python/WhileTest.java
@@ -3,7 +3,7 @@ package simae.lib.python;
 import org.junit.jupiter.api.Test;
 import simae.SimaeLauncher;
 import simae.lib.Lenguaje;
-import simae.lib.cPlusPlus.Tests;
+import simae.lib.cPlusPlus.es.Tests;
 
 import java.io.IOException;
 


### PR DESCRIPTION
Esta Pull Request realiza las modificaciones necesarias para que el código sea marcado en orden sin necesidad de ordenar las marcas, y modifica los /n por nl en los tests para funcionar entre distintos sistemas operativos.

Modificaciones:
* Eliminada la estructura ifelse en la gramática, y reemplazada por if y else separados.
* Modificado /n por nl en los tests.
* Arreglado el orden en if/else en C++.