### PR TITLE
Eliminado parametro -p para coincidir con GUI

### DIFF
--- a/innosetup/instrucciones.txt
+++ b/innosetup/instrucciones.txt
@@ -16,7 +16,6 @@ Parámetros posibles:
 
 Parámetro      Nombre completo        Descripción 
 -o             --out=<outputFile>     Archivo de salida (por defecto es <inputFile>)
--p             --lang=<language>      Lenguaje de programación del archivo de entrada (java8, c++, python3)
 -l             --locale=<locale>      Idioma utilizado para el marcado y mensajes
 -u             --untag                Quitar las marcas de SIMAE de <inputFile>
 -s             --sound                Reproduce un sonido para indicar el resultado del proceso (solo CLI)

--- a/simae/src/main/java/simae/core/languages/Interfaz_en.java
+++ b/simae/src/main/java/simae/core/languages/Interfaz_en.java
@@ -16,7 +16,6 @@ public class Interfaz_en extends ListResourceBundle {
                     {"untag", "Removes SIMAE tags from <inputFile>"},
                     {"input", "Input filename"},
                     {"output", "Output filename (default is <inputFile>)"},
-                    {"programmingLanguage", "Input file programming language (java8, c++, python3)"},
                     {"gui", "Shows graphical interface"},
                     {"version", "Version of SIMAE"},
                     {"help", "Displays this usage description"},

--- a/simae/src/main/java/simae/core/languages/Interfaz_es.java
+++ b/simae/src/main/java/simae/core/languages/Interfaz_es.java
@@ -16,7 +16,6 @@ public class Interfaz_es extends ListResourceBundle {
                     {"language", "Idioma utilizado para el marcado y mensajes"},
                     {"input", "Archivo de entrada"},
                     {"output", "Archivo de salida (por defecto es <inputFile>)"},
-                    {"programmingLanguage", "Lenguaje de programación del archivo de entrada (java8, c++, python3)"},
                     {"gui", "Muestra la interfaz gráfica"},
                     {"version", "Versión de SIMAE"},
                     {"untag", "Quitar las marcas de SIMAE de <inputFile>"},

--- a/simae/src/main/java/simae/standalone/cli/CommandLineInterface.java
+++ b/simae/src/main/java/simae/standalone/cli/CommandLineInterface.java
@@ -34,7 +34,6 @@ public class CommandLineInterface implements Callable<Integer> {
 	@CommandLine.Option(names = {"-o", "--out"}, paramLabel = "<outputFile>", required=false, descriptionKey = "output")
 	static String outputFile;
 
-	@CommandLine.Option(names = {"-p", "--lang"}, paramLabel = "<language>", descriptionKey="programmingLanguage", required=false)
 	static String languageString;
 
 	@CommandLine.Option(names = { "-l", "--locale" }, paramLabel = "<locale>", descriptionKey = "language")
@@ -114,31 +113,20 @@ public class CommandLineInterface implements Callable<Integer> {
 				outputFile = inputFile;
 			}
 
-			Lenguaje programmingLenguage;
-
-			//if (lenguajeString == null) {
-				languageString = this.getFileExtension(inputFile);
-			//}
+			languageString = this.getFileExtension(inputFile);
 
 
 			switch (languageString) { //FIXME: esto esta hardcodeado en muchos lugares
-				//case "c++":
 				case ".cpp":
-					programmingLenguage = Lenguaje.CPLUSPLUS;
 					languageString = "c++";
 					break;
-				//case "java8":
 				case ".java":
-					programmingLenguage = Lenguaje.JAVA8;
 					languageString = "java8";
 					break;
-				//case "python3":
 				case ".py":
-					programmingLenguage = Lenguaje.PYTHON3;
 					languageString = "python3";
 					break;
 				case ".cs":
-					programmingLenguage = Lenguaje.CSHARP;
 					languageString = "csharp";
 					break;
 				default:


### PR DESCRIPTION
El parámetro -p no estaba cumpliendo ninguna función, y se había removido de la GUI para simplificar la aplicación. Se propone eliminarlo también de la CLI.