### PR TITLE
Fix VS Code extension JRE installation

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/simae-plugins/vs_code/build.gradle
+++ b/simae-plugins/vs_code/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'com.github.node-gradle.node' version '3.0.0'
 }
 
-version = '1.0.0'
+version = '1.0.1'
 
 repositories {
     mavenCentral()

--- a/simae-plugins/vs_code/src/functions.js
+++ b/simae-plugins/vs_code/src/functions.js
@@ -1,6 +1,7 @@
 const vscode = require('vscode');
 const jschardet = require('jschardet');
 const path = require('path');
+const fs = require('fs');
 const { spawn } = require('child_process');
 const { msg } = require('./locale.js');
 const { Marca } = require('./models/marca.js')
@@ -48,8 +49,14 @@ async function armarMultimap(filePath, context, editor, idioma) {
     return null;
   }
 
-  const javaBin = path.join(jrePath, 'bin', 'java');
-  
+  let javaBin = path.join(jrePath, 'bin', 'java');
+  // Fix stale global state if 'jrePath' has an extra 'jre' folder
+  if (!fs.existsSync(javaBin) && jrePath.endsWith('jre')) {
+    jrePath = path.dirname(jrePath);
+    javaBin = path.join(jrePath, 'bin', 'java');
+    context.globalState.update('jrePath', jrePath);
+  }
+
   process.env['JAVA_HOME'] = jrePath;
   process.env['PATH'] = `${path.join(jrePath, 'bin')}${path.delimiter}${process.env['PATH']}`;
 

--- a/simae-plugins/vs_code/src/package-lock.json
+++ b/simae-plugins/vs_code/src/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simae",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simae",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "child_process": "^1.0.2",
         "decompress": "^4.2.1",

--- a/simae-plugins/vs_code/src/package.json
+++ b/simae-plugins/vs_code/src/package.json
@@ -2,7 +2,7 @@
   "name": "simae",
   "displayName": "SIMAE",
   "description": "SIMAE brinda asistencia a la programación para desarrolladores con discapacidad visual, proporcionando información contextual de las estructuras contenidas dentro del código fuente.",
-  "version": "0.1.0",
+  "version": "1.0.1",
   "publisher": "tiflo-sf",
   "engines": {
     "vscode": "^1.77.0"
@@ -96,7 +96,7 @@
     "postInstall": "node ./src/setup.js",
     "pretest": "npm run lint",
     "test": "node ./test/runTest.js",
-    "vsce:package": "vsce package"
+    "vsce:package": "npx @vscode/vsce package"
   },
   "devDependencies": {
     "@types/glob": "^8.1.0",

--- a/simae-plugins/vs_code/src/setup.js
+++ b/simae-plugins/vs_code/src/setup.js
@@ -34,28 +34,74 @@ function obtenerURL() {
  * @param {string} url - URL de descarga del JRE.
  * @param {string} jrePath - PATH del archivo descargado.
  */
-function descargarJRE(urlStr, jrePath) {
+function descargarJRE(urlStr, jrePath, redirecciones = 0) {
   return new Promise((resolve, reject) => {
-    https.get(urlStr, (response) => {
-      if (response.statusCode >= 300 && response.statusCode < 400 && response.headers.location) {
-        let redirectUrl = response.headers.location;
-        if (!redirectUrl.startsWith('http')) {
-          const { URL } = require('url');
-          const urlObj = new URL(urlStr);
-          redirectUrl = urlObj.origin + redirectUrl;
+    if (redirecciones > 5) {
+      return reject(new Error('Demasiadas redirecciones al intentar descargar el JRE.'));
+    }
+
+    let finalizado = false;
+
+    function limpiarArchivoParcial() {
+      fs.unlink(jrePath, (err) => {
+        if (err && err.code !== 'ENOENT') {
+          console.error('Error al limpiar archivo parcial:', err);
         }
-        return resolve(descargarJRE(redirectUrl, jrePath));
+      });
+    }
+
+    function fallar(err) {
+      if (finalizado) return;
+      finalizado = true;
+      limpiarArchivoParcial();
+      reject(err);
+    }
+
+    const req = https.get(urlStr, (response) => {
+      if (response.statusCode >= 300 && response.statusCode < 400 && response.headers.location) {
+        const { URL } = require('url');
+        const redirectUrl = new URL(response.headers.location, urlStr).toString();
+        return resolve(descargarJRE(redirectUrl, jrePath, redirecciones + 1));
       }
+
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        response.resume();
+        return fallar(new Error(`Error HTTP ${response.statusCode}`));
+      }
+
       const archivo = fs.createWriteStream(jrePath);
+
+      archivo.on('error', (err) => {
+        fallar(new Error(`Error escribiendo el archivo local: ${err.message}`));
+      });
+
+      response.on('error', (err) => {
+        fallar(new Error(`Error en el stream de respuesta: ${err.message}`));
+      });
+
+      response.on('aborted', () => {
+        fallar(new Error('La conexión de descarga se abortó inesperadamente.'));
+      });
+
       response.pipe(archivo);
+
       archivo.on('finish', () => {
-        archivo.close(() => resolve(jrePath));
+        if (finalizado) return;
+        archivo.close((err) => {
+          if (finalizado) return;
+          if (err) return fallar(err);
+          finalizado = true;
+          resolve(jrePath);
+        });
       });
-    }).on('error', (err) => {
-      fs.unlink(jrePath, (errs) => {
-        if (errs) console.error(errs);
-      });
-      reject(err.message);
+    });
+
+    req.on('error', (err) => {
+      fallar(new Error(`Error en la petición de red: ${err.message}`));
+    });
+
+    req.setTimeout(30000, () => {
+      req.destroy(new Error('Timeout de descarga excedido.'));
     });
   });
 }

--- a/simae-plugins/vs_code/src/setup.js
+++ b/simae-plugins/vs_code/src/setup.js
@@ -17,7 +17,7 @@ function obtenerURL() {
   let url;
 
   if (platform === 'win32') {
-    url = 'https://firebasestorage.googleapis.com/v0/b/simae-67068.appspot.com/o/jre_win.zip?alt=media&token=da0e97e4-5edc-413d-ae8c-ecb4381e6232';
+    url = 'https://github.com/tiflo-sf/simae/releases/download/v1.0.0/jre_win.zip';
   } else if (platform === 'darwin') {
     url = 'JRE_MACOS'; //TO-DO
   } else if (platform === 'linux') {
@@ -34,17 +34,26 @@ function obtenerURL() {
  * @param {string} url - URL de descarga del JRE.
  * @param {string} jrePath - PATH del archivo descargado.
  */
-function descargarJRE(url, jrePath) {
+function descargarJRE(urlStr, jrePath) {
   return new Promise((resolve, reject) => {
-    const archivo = fs.createWriteStream(jrePath);
-    https.get(url, (response) => {
+    https.get(urlStr, (response) => {
+      if (response.statusCode >= 300 && response.statusCode < 400 && response.headers.location) {
+        let redirectUrl = response.headers.location;
+        if (!redirectUrl.startsWith('http')) {
+          const { URL } = require('url');
+          const urlObj = new URL(urlStr);
+          redirectUrl = urlObj.origin + redirectUrl;
+        }
+        return resolve(descargarJRE(redirectUrl, jrePath));
+      }
+      const archivo = fs.createWriteStream(jrePath);
       response.pipe(archivo);
       archivo.on('finish', () => {
         archivo.close(() => resolve(jrePath));
       });
     }).on('error', (err) => {
       fs.unlink(jrePath, (errs) => {
-        if (errs) throw err;
+        if (errs) console.error(errs);
       });
       reject(err.message);
     });
@@ -134,8 +143,10 @@ async function setup(context) {
             const instalado = await javaInstalado();
             if(!instalado){
                 let jrePath = await instalarJRE(context);
-                jrePath = path.join(jrePath, 'jre');
-                context.globalState.update('jrePath', jrePath); 
+                if (fs.existsSync(path.join(jrePath, 'jre'))) {
+                    jrePath = path.join(jrePath, 'jre');
+                }
+                context.globalState.update('jrePath', jrePath);
             } else {
                 const javaPath = await getJavaPath()
                 context.globalState.update('jrePath', javaPath);

--- a/simae/build.gradle
+++ b/simae/build.gradle
@@ -9,7 +9,7 @@ plugins {
     id 'com.github.node-gradle.node' version '3.0.0'
 }
 
-version = '1.0.0'
+version = '1.0.1'
 
 compileJava {
     options.compilerArgs += ["-Aproject=${project.group}/${project.name}"]
@@ -60,7 +60,7 @@ task generateVersionFile {
 }
 
 shadowJar {
-    classifier = null
+    archiveClassifier.set('')
 }
 
 build {


### PR DESCRIPTION
## Descripción
Este PR soluciona un problema crítico donde la extensión de VS Code fallaba silenciosamente al intentar descargar y configurar el JRE de Java en entornos limpios (como máquinas virtuales sin Java preinstalado), o fallaba al reutilizar configuraciones rotas almacenadas en la caché del editor.

## Cambios realizados
- **Resolución de redirecciones HTTP:** Se actualizó la función `descargarJRE` en `setup.js` para seguir correctamente redirecciones (HTTP 302). Anteriormente, la descarga desde URLs (como SharePoint o GitHub Releases) fallaba porque `https.get` en Node.js no sigue redirecciones por defecto, generando un archivo ZIP corrupto.
- **Limpieza de caché de rutas (globalState):** Se implementó una rutina de auto-recuperación en `functions.js`. Si VS Code mantiene almacenada una ruta de JRE antigua y defectuosa (ej. con una subcarpeta `jre` extra inexistente), la extensión ahora la detecta, la limpia dinámicamente y auto-corrige la ejecución.
- **Actualización de origen de JRE:** Se cambió la URL del JRE en el código fuente para que apunte directamente a **GitHub Releases** (`v1.0.0/jre_win.zip`), ofreciendo mayor estabilidad.
- **Mejoras en el empaquetado y compatibilidad:** 
  - Se cambió el script de empaquetado a `npx @vscode/vsce package` en el `package.json` para que sea auto-contenido, sin requerir instalaciones globales obsoletas.
  - Se actualizó el Gradle Wrapper local a la versión 8.10 para soportar JDKs modernos (Java 23+) y se arregló la sintaxis obsoleta del `shadowJar` (`archiveClassifier`) para que el proyecto compile correctamente en entornos recientes.